### PR TITLE
Review mixed source type handling for rendering

### DIFF
--- a/pkg/apis/application/v1alpha1/types.go
+++ b/pkg/apis/application/v1alpha1/types.go
@@ -3507,10 +3507,11 @@ func (source *ApplicationSource) ExplicitType() (*ApplicationSourceType, error) 
 				appType := ApplicationSourceTypeDirectory
 				return &appType, nil
 			}
-			// For Directory + Helm, Directory is the primary type for scanning
+			// For Directory + Helm, Helm is the primary type for processing
+			// Directory specifies the location, but Helm specifies the processing method
 			if (appTypes[0] == ApplicationSourceTypeDirectory && appTypes[1] == ApplicationSourceTypeHelm) ||
 				(appTypes[0] == ApplicationSourceTypeHelm && appTypes[1] == ApplicationSourceTypeDirectory) {
-				appType := ApplicationSourceTypeDirectory
+				appType := ApplicationSourceTypeHelm
 				return &appType, nil
 			}
 		}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [x] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
**Fix: Ensure Helm rendering for Directory + Helm source combinations (related to #24366)**

This PR addresses a critical issue where applications configured with both `ApplicationSourceTypeDirectory` and `ApplicationSourceTypeHelm` in `ExplicitType()` incorrectly default to `ApplicationSourceTypeDirectory`. This behavior bypasses Helm chart rendering entirely, ignoring Helm values and configurations, and preventing proper processing of Helm charts within a directory structure.

The change ensures that when both Directory and Helm types are present, the Helm rendering engine is correctly invoked. This is essential for scenarios like App-of-Apps patterns and mixed content directories where Helm charts require proper templating and manifest generation. This PR aims to correct the flaw identified in the approach for `Directory` + `Helm` combinations, ensuring Helm-specific logic is not skipped.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b873a5f-9aeb-4412-a1fc-298bac6ce20f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b873a5f-9aeb-4412-a1fc-298bac6ce20f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

